### PR TITLE
Feature/actions release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
       - 'LICENSE'
 
 jobs:
-  lighthouse:
+  test:
     runs-on: ubuntu-latest
     
     steps:
@@ -76,14 +76,59 @@ jobs:
           show_table_in_summary: true
 
       # Test the action using itself
-      # - name: Run PageInsights Action (Sitemap)
-      #   uses: ./
-      #   with:
-      #     device: 'DESKTOP'
-      #     page_insights_key: ${{ secrets.PAGE_INSIGHTS_KEY }}
-      #     performance_threshold: '75'
-      #     seo_threshold: '75'
-      #     accessibility_threshold: '75'
-      #     best_practices_threshold: '75'
-      #     mode: 'SITEMAP'
-      #     sitemap_url: 'https://leothelegion.net/sitemap-index.xml'
+      - name: Run PageInsights Action (Sitemap)
+        uses: ./
+        with:
+          device: 'DESKTOP'
+          page_insights_key: ${{ secrets.PAGE_INSIGHTS_KEY }}
+          performance_threshold: '75'
+          seo_threshold: '75'
+          accessibility_threshold: '75'
+          best_practices_threshold: '75'
+          mode: 'SITEMAP'
+          sitemap_url: 'https://leothelegion.net/sitemap-index.xml'
+
+  release:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Get version from package.json
+        id: get_version
+        run: echo "::set-output name=version::$(node -p -e "require('./package.json').version")"
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.get_version.outputs.version }}
+          release_name: v${{ steps.get_version.outputs.version }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./dist
+          asset_name: dist.zip
+          asset_content_type: application/zip

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # TypeScript compilation output
-#dist/
+dist/
 lib/
 out/
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-lighthouse-action",
-  "version": "1.0.0",
+  "version": "0.4.0",
   "description": "A GitHub Action to run Lighthouse audits on your web pages",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow and a version change in the `package.json` file. The key changes are the renaming and restructuring of jobs in the workflow file, and the addition of a release process.

Changes in GitHub Actions workflow:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L17-R17): Renamed the `lighthouse` job to `test` and re-enabled the `Run PageInsights Action (Sitemap)` step. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L17-R17) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L79-R134)
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L79-R134): Added a new `release` job that runs on the `master` branch. This job includes steps to checkout the code, set up Node.js, install dependencies, build the project, get the version from `package.json`, create a release, and upload the release asset.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.0.0` to `0.4.0`.