### PR TITLE
Update GitHub Actions workflow to trigger release job on main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
           sitemap_url: 'https://leothelegion.net/sitemap-index.xml'
 
   release:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
     steps:


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/main.yml` file. The change updates the branch reference for the release job to align with the new branch naming convention.

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L92-R92): Changed the branch reference for the release job from 'refs/heads/master' to 'refs/heads/main'.