### PR TITLE
Update GitHub Actions workflow to zip dist folder and upload as release asset

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,9 @@ jobs:
 
       - name: Build
         run: npm run build
+        
+      - name: Zip dist folder
+        run: cd dist && zip -r ../dist.zip .
 
       - name: Get version from package.json
         id: get_version
@@ -113,22 +116,9 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.get_version.outputs.version }}
-          release_name: v${{ steps.get_version.outputs.version }}
           draft: false
           prerelease: false
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist
-          asset_name: dist.zip
-          asset_content_type: application/zip
+          files: dist.zip


### PR DESCRIPTION
This pull request includes modifications to the GitHub Actions workflow file `.github/workflows/main.yml` to improve the build and release process. The most important changes include adding a step to zip the `dist` folder and updating the action used for creating a release.

Updates to the build and release process:

* Added a step to zip the `dist` folder before creating a release. (`.github/workflows/main.yml`)
* Replaced the `actions/create-release` action with `softprops/action-gh-release` and simplified the release asset upload process. (`.github/workflows/main.yml`)