### PR TITLE
Update GitHub Actions to use action-gh-release@v2 for creating releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.get_version.outputs.version }}
           draft: false


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow configuration to use a newer version of the `softprops/action-gh-release` action.

Changes to GitHub Actions workflow:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L119-R119): Updated `softprops/action-gh-release` action from version `v1` to `v2`.