### PR TITLE
Update GitHub Actions workflow to commit and push dist folder changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ on:
       - '**.md'
       - 'docs/**'
       - 'LICENSE'
+      - 'dist/**'
 
 jobs:
   test:
@@ -92,6 +93,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -106,20 +109,27 @@ jobs:
 
       - name: Build
         run: npm run build
-        
-      - name: Zip dist folder
-        run: cd dist && zip -r ../dist.zip .
+
+      - name: Configure Git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
 
       - name: Get version from package.json
         id: get_version
         run: echo "::set-output name=version::$(node -p -e "require('./package.json').version")"
+
+      - name: Commit dist
+        run: |
+          git add dist -f
+          git commit -m "chore: update dist for version ${{ github.ref_name }}"
+          git push origin HEAD:main
 
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.get_version.outputs.version }}
-          draft: false
+          draft: true
           prerelease: false
-          files: dist.zip
           token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # TypeScript compilation output
-dist/
+#dist/
 lib/
 out/
 


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflow configuration in the `.github/workflows/main.yml` file. The changes aim to enhance the build and release process by adding new steps and modifying existing ones.

Key changes to the GitHub Actions workflow:

* Added the `dist/**` pattern to the list of paths that will not trigger the workflow.
* Added `permissions` to allow write access to contents during the workflow execution.
* Replaced the step that zips the `dist` folder with steps to configure Git and commit the `dist` folder.
* Modified the release creation step to set the `draft` attribute to `true` and removed the `files` attribute.