### PR TITLE
Hotfix/retry

### DIFF
--- a/src/RequestQueue.ts
+++ b/src/RequestQueue.ts
@@ -19,7 +19,7 @@ class Handler {
         this.request = request;
         this.resolve = resolve;
         this.reject = reject;
-        this.retry = 0;
+        this.retry = 3;
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,12 @@ export async function run(): Promise<void> {
         // Core functionality using config values
     } catch (error) {
         if (error instanceof Error) {
+
+            // If the error is due to the environment 
+            // not supporting job summaries, ignore it
+            if (error.message === 'Unable to find environment variable for $GITHUB_STEP_SUMMARY. Check if your runtime environment supports job summaries.')
+                return;
+
             core.setFailed(error.message);
         }
     }


### PR DESCRIPTION
This pull request includes changes to the `src/RequestQueue.ts` and `src/index.ts` files to improve error handling and retry logic.

Enhancements to error handling:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R16-R21): Added a check to ignore errors related to unsupported job summaries by the environment. This prevents the application from failing when the `$GITHUB_STEP_SUMMARY` environment variable is not found.

Improvements to retry logic:

* [`src/RequestQueue.ts`](diffhunk://#diff-0ecdf3ec75f02d7c2f47ba6ab6299196dea8fe116b19b030c5e4a497fdf89131L22-R22): Increased the initial retry count from 0 to 3, allowing for more immediate retry attempts upon failure.