### PR TITLE
ci: allow commit dist step to continue on error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,7 @@ jobs:
         run: echo "::set-output name=version::$(node -p -e "require('./package.json').version")"
 
       - name: Commit dist
+        continue-on-error: true
         run: |
           git add dist -f
           git commit -m "chore: update dist for version ${{ github.ref_name }}"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/main.yml` file. The change adds the `continue-on-error: true` property to the "Commit dist" step to ensure the workflow continues even if there is an error during this step.