### PR TITLE
ci: simplify dist file change detection in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,20 +117,7 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Check if dist has changed
-        id: check_dist
-        run: |
-          HASH=$(find dist -type f -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1)
-          if [ "$HASH" = "$(grep hash $GITHUB_EVENT_PATH | cut -d'=' -f2)" ]; then
-            echo "hasChanged=false" >> $GITHUB_OUTPUT
-            echo "No changes in dist"
-          else
-            echo "hasChanged=true" >> $GITHUB_OUTPUT
-            echo "Changes detected in dist"
-          fi
-
       - name: Configure Git
-        if: ${{ steps.check_dist.outputs.hasChanged == 'true' }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -140,7 +127,6 @@ jobs:
         run: echo "::set-output name=version::$(node -p -e "require('./package.json').version")"
 
       - name: Configure SSH
-        if: ${{ steps.check_dist.outputs.hasChanged == 'true' }}
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_rsa
@@ -148,17 +134,23 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
       
       - name: Commit dist
-        if: ${{ steps.check_dist.outputs.hasChanged == 'true' }}
+        id: commit_status
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git remote set-url origin git@github.com:${{ github.repository }}.git
           git add dist -f
-          git commit -m "chore: update dist for version ${{ github.ref_name }}"
-          git push origin HEAD:main
+          if git diff --staged --quiet; then
+            echo "hasChanges=false" >> $GITHUB_OUTPUT
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update dist for version ${{ github.ref_name }}"
+            git push origin HEAD:main
+            echo "hasChanges=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create Release
-        if: ${{ steps.check_dist.outputs.hasChanged == 'true' }}
+        if: ${{ steps.commit_status.outputs.hasChanges == 'true' }}
         id: create_release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow to simplify and improve the handling of changes in the `dist` directory. The most important changes include removing the redundant step of checking for changes in `dist` and incorporating the check directly into the commit step.

Simplifications and improvements in GitHub Actions workflow:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L120-L133): Removed the step that checks if `dist` has changed before configuring Git, SSH, and committing changes. The check is now performed within the commit step itself. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L120-L133) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L143-R153)
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L143-R153): Updated the commit step to set the `commit_status` output based on whether there are changes to commit, and adjusted subsequent steps to use this new output.