### PR TITLE
ci: update README and action.yml to reflect PageSpeed Insights branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 [![PageInsights CI](https://github.com/LeoTheLegion/easy-lighthouse-action/actions/workflows/main.yml/badge.svg)](https://github.com/LeoTheLegion/easy-lighthouse-action/actions/workflows/main.yml)
 
-# Page Insights Action
+# Easy Lighthouse Action
 
-This project is a custom GitHub Action that runs Google Page Insights on a list of URLs or a sitemap.
+This project is a custom GitHub Action that runs Google PageSpeed Insights on a list of URLs or a sitemap.
 
 ## Overview
 
-This GitHub Action is designed to perform Google Page Insights audits. Depending on your thresholds, the action will pass or fail. **It requires a Google Page Insights API key**.
+This GitHub Action is designed to perform Google PageSpeed Insights audits. Depending on your thresholds, the action will pass or fail. **It requires a Google PageSpeed Insights API key**.
 
 ## Getting Started
 
@@ -20,7 +20,7 @@ To use this action in your GitHub workflows, follow these steps:
      example-job:
        runs-on: ubuntu-latest
        steps:
-         - name: Run Page Insights Action
+         - name: Run PageSpeed Insights Action
            uses: leothelegion/easy-lighthouse-action@v0.4.1
            with:
              device: 'mobile'
@@ -43,7 +43,7 @@ To use this action in your GitHub workflows, follow these steps:
 |----------------------------|-----------------------------------------|----------|
 | `urls`                     | URLs to audit (separated by new lines)  | Yes      |
 | `device`                   | Device to emulate (mobile/desktop)      | Yes      |
-| `page_insights_key`        | Google Page Insights API key            | Yes      |
+| `page_insights_key`        | Google PageSpeed Insights API key            | Yes      |
 | `performance_threshold`    | Performance threshold                   | No       |
 | `seo_threshold`            | SEO threshold                           | No       |
 | `accessibility_threshold`  | Accessibility threshold                 | No       |
@@ -106,7 +106,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Run Page Insights Action
+      - name: Run PageSpeed Insights Action
         uses: leothelegion/easy-lighthouse-action@v0.4.1
         with:
           device: 'mobile'
@@ -128,7 +128,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Run Page Insights Action
+      - name: Run PageSpeed Insights Action
         uses: leothelegion/easy-lighthouse-action@v0.4.1
         with:
           urls: |

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
-name: 'Page Insights Action'
+name: 'Easy Lighthouse Action'
 description: |
-    Run Google Page Insights on a list of URLs or a sitemap.
+    Run Google PageSpeed Insights on a list of URLs or a sitemap.
     Depending on your thresholds, the action will pass or fail.
-    Requires a Google Page Insights API key.
+    Requires a Google PageSpeed Insights API key.
 
 inputs:
   urls:
@@ -12,7 +12,7 @@ inputs:
     default: 'mobile'
     required: true
   page_insights_key:
-    description: 'Google Page Insights API key'
+    description: 'Google PageSpeed Insights API key'
     required: true
   performance_threshold:
     description: 'Performance threshold'


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `action.yml` files to rename the action and correct the terminology from "Google Page Insights" to "Google PageSpeed Insights."

Changes to terminology and naming:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R9): Updated the action name from "Page Insights Action" to "Easy Lighthouse Action" and corrected all instances of "Google Page Insights" to "Google PageSpeed Insights." [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R23) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R46) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R109) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L131-R131)
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L1-R5): Renamed the action to "Easy Lighthouse Action" and updated the description and input key to use "Google PageSpeed Insights." [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L1-R5) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L15-R15)